### PR TITLE
chore: upgrade pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git@github.com:nl-design-system/hall-of-fame.git",
     "directory": "."
   },
-  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
   "engines": {
     "//": "Update @types/node when updating this node version",
     "node": ">=24 <=25",


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  We currently pin 11.5 but there has been a lot of development since then.  Check out their [changelogs](https://pnpm.io/blog/releases/11.6).  Notable changes are minor security improvements and a bugfix that affected [lux](https://github.com/nl-design-system/lux/pull/650).
