### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,14 +6,14 @@ packages:
   - packages/tokens/*
 
 overrides:
-  shell-quote@>=1.1.0 <=1.8.3: ">=1.8.4"
+  shell-quote@>=1.1.0 <=1.8.3: '>=1.8.4'
 allowBuilds:
-  "@parcel/watcher": true
+  '@parcel/watcher': true
   esbuild: true
   unrs-resolver: true
 engineStrict: true
 saveExact: true
-savePrefix: ""
+savePrefix: ''
 strictPeerDependencies: false
 autoInstallPeers: false
 provenance: true

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -17,5 +17,12 @@ export default {
         singleQuote: false,
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
